### PR TITLE
Configure orchestrator lambda name from env var

### DIFF
--- a/lambda.py
+++ b/lambda.py
@@ -36,7 +36,9 @@ def common_options(function):
     )(function)
     function = click.option(
         "--orchestrator-function-name",
-        default="orchestrator",
+        required=True,
+        envvar="ORCHESTRATOR_FUNCTION_NAME",
+        show_envvar=True,
         help="Name of the orchestrator lambda function",
     )(function)
     function = click.option(


### PR DESCRIPTION
I'm trying to set multiple devs set up to run their own worker lambdas in the cloud. Since the orchestator is pinned to a specific worker function name, it seems better for each dev to have their own orchestrator. Accordingly, I think it makes sense to remove the default – so they don't inadvertantly try to use each others'.