### PR TITLE
Remove broken feature and get 100% coverage on S3

### DIFF
--- a/werkit/s3.py
+++ b/werkit/s3.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 
 
 @contextmanager
-def temp_file_on_s3(local_path, bucket, key=None, verbose=False, ret_etag=False):
+def temp_file_on_s3(local_path, bucket, key=None, verbose=False):
     """
     Copy the given path to S3. Delete the object from S3 when the block
     exits.
@@ -24,10 +24,10 @@ def temp_file_on_s3(local_path, bucket, key=None, verbose=False, ret_etag=False)
 
     file_on_s3 = f"s3://{bucket}/{key}"
     pif(f"Uploading {local_path} to {file_on_s3}")
-    response = s3_client.upload_file(Filename=local_path, Bucket=bucket, Key=key)
+    s3_client.upload_file(Filename=local_path, Bucket=bucket, Key=key)
 
     try:
-        yield (key, response["ETag"]) if ret_etag else key
+        yield key
     finally:
         pif(f"Removing {file_on_s3}")
         s3_client.delete_object(Bucket=bucket, Key=key)

--- a/werkit/test_s3.py
+++ b/werkit/test_s3.py
@@ -3,7 +3,7 @@ import uuid
 import boto3
 from botocore.exceptions import ClientError
 import pytest
-from .s3 import temp_file_on_s3
+from .s3 import temp_file_on_s3, temp_file_on_s3_from_string
 
 
 @pytest.fixture
@@ -36,9 +36,8 @@ def test_temp_file_on_s3(example_file, test_bucket):
     ) as key:
         assert key == target_key
         s3_client = boto3.client("s3")
-        assert s3_client.get_object(Bucket=test_bucket, Key=target_key)[
-            "Body"
-        ].read() == bytes(EXAMPLE_CONTENTS, "utf-8")
+        response = s3_client.get_object(Bucket=test_bucket, Key=target_key)
+        assert response["Body"].read() == bytes(EXAMPLE_CONTENTS, "utf-8")
 
     # Make sure the key is removed after the context handler is closed
     with pytest.raises(ClientError, match=r"Not Found$"):
@@ -50,4 +49,27 @@ def test_temp_file_on_s3_with_implicit_key(example_file, test_bucket):
         local_path=example_file, bucket=test_bucket, verbose=True
     ) as key:
         assert key.startswith("example_")
+        assert key.endswith(".txt")
+
+
+def test_temp_file_on_s3_from_string(test_bucket):
+    target_key = f"test_{uuid.uuid4().hex}.txt"
+
+    with temp_file_on_s3_from_string(
+        contents=EXAMPLE_CONTENTS, bucket=test_bucket, key=target_key, verbose=True
+    ) as key:
+        assert key == target_key
+        s3_client = boto3.client("s3")
+        response = s3_client.get_object(Bucket=test_bucket, Key=target_key)
+        assert response["Body"].read() == bytes(EXAMPLE_CONTENTS, "utf-8")
+
+    # Make sure the key is removed after the context handler is closed
+    with pytest.raises(ClientError, match=r"Not Found$"):
+        s3_client.head_object(Bucket=test_bucket, Key=target_key)
+
+
+def test_temp_file_on_s3_from_string_with_implicit_key(test_bucket):
+    with temp_file_on_s3_from_string(
+        contents=EXAMPLE_CONTENTS, bucket=test_bucket, extension=".txt", verbose=True
+    ) as key:
         assert key.endswith(".txt")


### PR DESCRIPTION
It turns out `upload_file` does not return the ETag.