### PR TITLE
Properly provide config to scheduled job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,6 +100,7 @@ workflows:
             branches:
               only: main
     jobs:
-      - main
+      - main:
+          context: "Metabolize OSS AWS"
       - lint
       - format


### PR DESCRIPTION
This job is using [CircleCI contexts](https://circleci.com/docs/2.0/contexts/?utm_medium=SEM&utm_source=gnb&utm_campaign=SEM-gb-DSA-Eng-uscan&utm_content=&utm_term=dynamicSearch-&gclid=CjwKCAiAnvj9BRA4EiwAuUMDf2ml2fwUOnEeZY-jquXohW1Z6yaMBc7v1Jo5YuhifqN_0V0bwBdpYBoCBf4QAvD_BwE) to get its AWS credentials. They work on PR builds but had to be enabled separately for the scheduled jobs such as [this one](https://app.circleci.com/pipelines/github/metabolize/werkit/585/workflows/2b4c1325-3926-42bf-9d15-0efdcbcd975e/jobs/1709).
