### PR TITLE
Explicitly specify AWS region for Lambda deploys

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,6 +376,8 @@ def create():
     from werkit.aws_lambda.deploy import perform_create
 
     perform_create(
+        # Region is required.
+        aws_region="us-east-1",
         function_name="myfunction",
         local_path_to_zipfile="build/function.zip",
         # The importable name of your handler function, which should have the
@@ -402,6 +404,7 @@ def update_code():
     from werkit.aws_lambda.deploy import perform_update_code
 
     perform_update_code(
+        aws_region="us-east-1",
         function_name="myfunction",
         local_path_to_zipfile="build/function.zip",
         # Required when the zipfile is larger than 50 MB.

--- a/werkit/aws_lambda/deploy.py
+++ b/werkit/aws_lambda/deploy.py
@@ -68,6 +68,7 @@ def _create_or_update(
 
 
 def perform_create(
+    aws_region,
     handler,
     function_name,
     role,
@@ -93,7 +94,7 @@ def perform_create(
         if memory_size is not None:
             extra_options["MemorySize"] = memory_size
 
-        boto3.client("lambda").create_function(
+        boto3.client("lambda", region_name=aws_region).create_function(
             FunctionName=function_name,
             Runtime=runtime,
             Role=role,
@@ -115,6 +116,7 @@ def perform_create(
 
 
 def perform_update_code(
+    aws_region,
     function_name,
     local_path_to_zipfile=None,
     s3_path_to_zipfile=None,
@@ -128,7 +130,7 @@ def perform_update_code(
         )
 
     def update(code_arguments):
-        boto3.client("lambda").update_function_code(
+        boto3.client("lambda", region_name=aws_region).update_function_code(
             FunctionName=function_name, **code_arguments
         )
 

--- a/werkit/aws_lambda/orchestrator_deploy.py
+++ b/werkit/aws_lambda/orchestrator_deploy.py
@@ -27,6 +27,7 @@ def prepare_zip_file(build_dir, path_to_orchestrator_zip):
 
 
 def deploy_orchestrator(
+    aws_region,
     build_dir,
     path_to_orchestrator_zip,
     orchestrator_function_name,
@@ -43,6 +44,7 @@ def deploy_orchestrator(
         env_vars["LAMBDA_WORKER_TIMEOUT"] = str(worker_timeout)
 
     perform_create(
+        aws_region=aws_region,
         local_path_to_zipfile=path_to_orchestrator_zip,
         handler="werkit.aws_lambda.default_handler.handler",
         function_name=orchestrator_function_name,
@@ -56,6 +58,7 @@ def deploy_orchestrator(
 
 
 def update_orchestrator_code(
+    aws_region,
     build_dir,
     path_to_orchestrator_zip,
     orchestrator_function_name,
@@ -65,6 +68,7 @@ def update_orchestrator_code(
     prepare_zip_file(build_dir, path_to_orchestrator_zip)
 
     perform_update_code(
+        aws_region=aws_region,
         local_path_to_zipfile=path_to_orchestrator_zip,
         function_name=orchestrator_function_name,
         s3_code_bucket=s3_code_bucket,

--- a/werkit/aws_lambda/test_integration.py
+++ b/werkit/aws_lambda/test_integration.py
@@ -10,6 +10,8 @@ from .orchestrator_deploy import deploy_orchestrator
 
 load_dotenv()
 
+AWS_REGION = "us-east-1"
+
 
 def role():
     """
@@ -39,6 +41,7 @@ def create_test_functions(
     if worker_should_throw:
         env_vars["SHOULD_THROW"] = "TRUE"
     perform_create(
+        aws_region=AWS_REGION,
         local_path_to_zipfile=path_to_worker_zip,
         handler="service.handler",
         function_name=worker_function_name,
@@ -48,6 +51,7 @@ def create_test_functions(
     )
 
     deploy_orchestrator(
+        aws_region=AWS_REGION,
         build_dir=str(tmpdir / "build"),
         path_to_orchestrator_zip=str(tmpdir / "orchestrator.zip"),
         orchestrator_function_name=orchestrator_function_name,


### PR DESCRIPTION
This has been pulled from the AWS_REGION / AWS_DEFAULT_REGION environment variables, however this approach is more flexible. It makes it possible to inject the region through code operating at various levels of abstraction, rather than programmatically setting an environment variable, which is messy.

An alternative could be to make the region optional, which would magically work some of the time, however making it explicit is simpler and it feels more Pythonic to provide one obvious way to do it. (I suppose passing `None` might trigger the default behavior of checking the environment.)