### PR TITLE
Manager: Require that callers set `manager.result` in the context handler as intended, and extract convenience methods

### DIFF
--- a/werkit/manager.py
+++ b/werkit/manager.py
@@ -57,15 +57,6 @@ class Manager:
         self.verbose = verbose
         self.time_precision = time_precision
 
-    @property
-    def result(self):
-        return self._result
-
-    @result.setter
-    def result(self, value):
-        self.config.schema.result.validate(value)
-        self._result = value
-
     def __enter__(self):
         self.start_time = datetime.datetime.now()
         return self

--- a/werkit/manager.py
+++ b/werkit/manager.py
@@ -108,5 +108,6 @@ class Manager:
 
         if self.verbose:
             print(
-                "Completed in {}".format(format_time(self.duration_seconds)), file=sys.stderr
+                "Completed in {}".format(format_time(self.duration_seconds)),
+                file=sys.stderr,
             )

--- a/werkit/manager.py
+++ b/werkit/manager.py
@@ -118,7 +118,7 @@ class Manager:
         # inside the block.
         try:
             self.result
-        except AttributeError as e:
+        except AttributeError:
             return self.note_compute_exception(
                 AttributeError("'result' has not been set on the 'Manager' instance")
             )

--- a/werkit/test_manager.py
+++ b/werkit/test_manager.py
@@ -85,9 +85,16 @@ def test_manager_passes_keyboard_interrupt():
             raise KeyboardInterrupt()
 
 
-def test_verbose(capfd):
+def test_verbose_success(capfd):
     with Manager(verbose=True) as manager:
         manager.result = 2
 
     out, err = capfd.readouterr()
     assert err == "Completed in 0.0 sec\n"
+
+def test_verbose_error(capfd):
+    with Manager(verbose=True) as manager:
+        raise ValueError()
+
+    out, err = capfd.readouterr()
+    assert err == "Errored in 0.0 sec\n"

--- a/werkit/test_manager.py
+++ b/werkit/test_manager.py
@@ -92,8 +92,9 @@ def test_verbose_success(capfd):
     out, err = capfd.readouterr()
     assert err == "Completed in 0.0 sec\n"
 
+
 def test_verbose_error(capfd):
-    with Manager(verbose=True) as manager:
+    with Manager(verbose=True):
         raise ValueError()
 
     out, err = capfd.readouterr()

--- a/werkit/test_manager.py
+++ b/werkit/test_manager.py
@@ -51,6 +51,28 @@ def test_manager_serializes_error():
     }
 
 
+@freeze_time("2019-12-31")
+def test_manager_serializes_expected_error_when_result_not_set():
+    runtime_info = {"foo": "bar"}
+    with Manager(runtime_info=runtime_info) as manager:
+        pass
+
+    assert (
+        manager.serialized_result["error"][-1]
+        == "AttributeError: 'result' has not been set on the 'Manager' instance\n"
+    )
+    del manager.serialized_result["error"]
+
+    assert manager.serialized_result == {
+        "success": False,
+        "result": None,
+        "error_origin": "compute",
+        "start_time": datetime.datetime(2019, 12, 31).astimezone().isoformat(),
+        "duration_seconds": 0,
+        "runtime_info": runtime_info,
+    }
+
+
 def test_manager_with_handle_exceptions_passes_error():
     with pytest.raises(ValueError):
         with Manager(handle_exceptions=False):


### PR DESCRIPTION
- Require that callers set `manager.result` in the context handler as intended, returning a compute error if not. To get the old behavior, set `manager.result = None`.
- Extract `note_compute_success()` and `note_compute_exception()` to allow more flexibility by consumers.