### PR TITLE
Remove rq dependency for now

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -104,7 +104,7 @@ unicode_backport = ["unicodedata2"]
 name = "click"
 version = "8.0.1"
 description = "Composable command line interface toolkit"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -116,7 +116,7 @@ importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 name = "colorama"
 version = "0.4.4"
 description = "Cross-platform colored terminal text."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -262,7 +262,7 @@ python-versions = ">=3.5"
 name = "importlib-metadata"
 version = "4.6.1"
 description = "Read metadata from Python packages"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -546,8 +546,8 @@ use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
 name = "rq"
 version = "1.1.0"
 description = "RQ is a simple, lightweight, library for creating background jobs, and processing them."
-category = "main"
-optional = true
+category = "dev"
+optional = false
 python-versions = ">=2.7"
 develop = false
 
@@ -603,7 +603,7 @@ python-versions = "*"
 name = "typing-extensions"
 version = "3.10.0.0"
 description = "Backported and Experimental Type Hints for Python 3.5+"
-category = "main"
+category = "dev"
 optional = false
 python-versions = "*"
 
@@ -632,7 +632,7 @@ python-versions = "*"
 name = "zipp"
 version = "3.5.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6"
 
@@ -644,12 +644,12 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 aws_lambda_build = ["executor"]
 client = ["boto3"]
 lambda_common = ["harrison"]
-parallel = ["redis", "rq"]
+parallel = ["redis"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7,<4"
-content-hash = "f903061385a8c9e969f9a0551b988d36c26076f59f31f0659e48d531a49d2d96"
+content-hash = "414e93590c81339ea9d6cdf192f67508a20c2ffddcb451b355253b8b69dd7843"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ boto3 = {version = "1.17.69", optional = true}
 executor = {version = ">=21.0", optional = true}
 harrison = {version = ">=2.0,<3.0", optional = true}
 redis = {version = "3.5.3", optional = true}
-# rq = {git = "https://github.com/rq/rq.git", rev = "cf501518534429640a9a6d14e022f9329225e701", optional = true}
 
 [tool.poetry.extras]
 aws_lambda_build = ["executor"]
@@ -44,6 +43,7 @@ pytest = "6.2.4"
 pytest-cov = "2.12.1"
 pytest-redis = "2.0.0"
 python-dotenv = ">=0.17.1<0.18"
+rq = {git = "https://github.com/rq/rq.git", rev = "cf501518534429640a9a6d14e022f9329225e701"}
 
 [build-system]
 # Lint requires setuptools.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,13 +23,13 @@ boto3 = {version = "1.17.69", optional = true}
 executor = {version = ">=21.0", optional = true}
 harrison = {version = ">=2.0,<3.0", optional = true}
 redis = {version = "3.5.3", optional = true}
-rq = {git = "https://github.com/rq/rq.git", rev = "cf501518534429640a9a6d14e022f9329225e701", optional = true}
+# rq = {git = "https://github.com/rq/rq.git", rev = "cf501518534429640a9a6d14e022f9329225e701", optional = true}
 
 [tool.poetry.extras]
 aws_lambda_build = ["executor"]
 client = ["boto3"]
 lambda_common = ["harrison"]
-parallel = ["redis", "rq"]
+parallel = ["redis"]
 
 [tool.poetry.dev-dependencies]
 black = "21.6b0"


### PR DESCRIPTION
It's causing this error on publish:

```
HTTPError: 400 Bad Request from https://upload.pypi.org/legacy/
Invalid value for requires_dist. Error: Can't have direct dependency: 'rq @ git+https://github.com/rq/rq.git@cf501518534429640a9a6d14e022f9329225e701 ; extra == "parallel"'
```

Probably at some point we just want to remove all this Redis stuff. Opened #172 to track that.