### PR TITLE
BREAKING CHANGE: Compute graph: Serialize without a compute class

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -835,6 +835,17 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "missouri"
+version = "0.1.0"
+description = "Read and write JSON in one line"
+category = "dev"
+optional = false
+python-versions = ">=3.8,<4"
+
+[package.dependencies]
+simplejson = ">=3,<4"
+
+[[package]]
 name = "more-itertools"
 version = "9.1.0"
 description = "More routines for operating on iterables, beyond itertools"
@@ -1422,7 +1433,7 @@ rds-graphile-worker = ["rds-graphile-worker-client"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.9,<4"
-content-hash = "f34db7508aadb368e99e600cd74b51aa5fdd955c2dfa16700d7b295238f6b264"
+content-hash = "3464fb35bb18db62e9a8c70db676f1ad0d445b560bc2cb08d0258182e25ae9ca"
 
 [metadata.files]
 artifax = [
@@ -1817,6 +1828,10 @@ mccabe = [
 mdurl = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
     {file = "mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"},
+]
+missouri = [
+    {file = "missouri-0.1.0-py3-none-any.whl", hash = "sha256:d5f4e7bf7ab97a6b2544cf2d5db066c35f3eb49b39a80655a4940fee52f826d8"},
+    {file = "missouri-0.1.0.tar.gz", hash = "sha256:049837603fa43bb1221821509254d79a3f332dddb3ddf6fbb6ae1481eddddfdc"},
 ]
 more-itertools = [
     {file = "more-itertools-9.1.0.tar.gz", hash = "sha256:cabaa341ad0389ea83c17a94566a53ae4c9d07349861ecb14dc6d0345cf9ac5d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ boto3 = {version = "1.20.32", optional = true}
 click = {version = "^8.0.3", optional = true}
 executor = {version = ">=21.0", optional = true}
 harrison = {version = "^2.0", optional = true}
+missouri = "0.1.0"
 # Pin to 0.18.0 to work around a Poetry install problem with 0.18.1 on OS X 10.15.7.
 # https://github.com/tobgu/pyrsistent/issues/241
 pyrsistent = {version = "0.18.0", optional = true}

--- a/werkit/compute/_manager.py
+++ b/werkit/compute/_manager.py
@@ -7,7 +7,7 @@ from ._formatting import format_time
 from ._schema import Schema
 from ._serialization import serialize_exception, serialize_result
 
-if t.TYPE_CHECKING:
+if t.TYPE_CHECKING:  # pragma: no cover
     from typing_extensions import Self
 
 

--- a/werkit/compute/_schema.py
+++ b/werkit/compute/_schema.py
@@ -1,7 +1,7 @@
 import typing as t
 from typing_extensions import Unpack
 
-if t.TYPE_CHECKING:
+if t.TYPE_CHECKING:  # pragma: no cover
     from jsonschema import Draft7Validator
 
 

--- a/werkit/compute/graph/__init__.py
+++ b/werkit/compute/graph/__init__.py
@@ -6,6 +6,7 @@ from ._custom_type import CustomType, JSONType  # noqa: F401
 from ._dependency_graph import (  # noqa: F401
     ComputeNode,
     DependencyGraph,
+    DependencyGraphJSONType,
     Input,
     Intermediate,
     Output,

--- a/werkit/compute/graph/__init__.py
+++ b/werkit/compute/graph/__init__.py
@@ -13,4 +13,4 @@ from ._dependency_graph import (  # noqa: F401
     intermediate,
     output,
 )
-from ._state_manager import StateManager  # noqa: F401
+from ._state_manager import StateManager, Store  # noqa: F401

--- a/werkit/compute/graph/_binding.py
+++ b/werkit/compute/graph/_binding.py
@@ -15,7 +15,7 @@ from ._state_manager import StateManager
 
 class DefaultStateManagerProtocol(t.Protocol):
     @property
-    def state_manager(self) -> StateManager:
+    def state_manager(self) -> StateManager:  # pragma: no cover
         ...
 
 

--- a/werkit/compute/graph/_built_in_type.py
+++ b/werkit/compute/graph/_built_in_type.py
@@ -11,6 +11,8 @@ else:
 
 BuiltInValueType = t.Union[t.Type[bool], t.Type[int], t.Type[float], t.Type[str]]
 
+BuiltInValueTypeName = t.Literal["bool", "number", "string"]
+
 
 def is_built_in_value_type(_type: t.Type) -> TypeGuard[BuiltInValueType]:
     return _type in (bool, int, float, numbers.Number, str)
@@ -29,3 +31,14 @@ def coerce_value_to_builtin_type(
         raise ValueError(
             f"{name} should be type {value_type.__name__}, not {type(value).__name__}"
         )
+
+
+def built_in_value_type_with_name(name: BuiltInValueTypeName) -> BuiltInValueType:
+    try:
+        return {
+            "boolean": bool,
+            "number": numbers.Number,
+            "string": str,
+        }[name]
+    except KeyError:
+        raise KeyError(f"Unknown value type: {name}")

--- a/werkit/compute/graph/_built_in_type.py
+++ b/werkit/compute/graph/_built_in_type.py
@@ -2,7 +2,7 @@ import numbers
 import sys
 import typing as t
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 10):  # pragma: no cover
     from typing import TypeGuard
 else:
     # TODO: Remove when Python 3.9 is dropped.

--- a/werkit/compute/graph/_custom_type.py
+++ b/werkit/compute/graph/_custom_type.py
@@ -1,7 +1,7 @@
 import typing as t
 from abc import ABC, abstractmethod
 
-if t.TYPE_CHECKING:
+if t.TYPE_CHECKING:  # pragma: no cover
     from jsonschema import Draft7Validator
 
 JSONType = t.Union[str, int, float, bool, None, t.Dict[str, t.Any], t.List[t.Any]]

--- a/werkit/compute/graph/_custom_type.py
+++ b/werkit/compute/graph/_custom_type.py
@@ -4,7 +4,7 @@ from abc import ABC, abstractmethod
 if t.TYPE_CHECKING:  # pragma: no cover
     from jsonschema import Draft7Validator
 
-JSONType = t.Union[str, int, float, bool, None, t.Dict[str, t.Any], t.List[t.Any]]
+JSONType = t.Union[str, int, float, bool, None, dict[str, t.Any], t.List[t.Any]]
 
 CanonicalType = t.TypeVar("CanonicalType")
 

--- a/werkit/compute/graph/_dependency_graph.py
+++ b/werkit/compute/graph/_dependency_graph.py
@@ -155,9 +155,9 @@ AttrType = t.TypeVar("AttrType")
 
 class DependencyGraphJSONType(t.TypedDict):
     schemaVersion: t.Literal[1]
-    inputs: t.Dict[str, InputJSONType]
-    intermediates: t.Dict[str, ComputeNodeJSONType]
-    outputs: t.Dict[str, ComputeNodeJSONType]
+    inputs: dict[str, InputJSONType]
+    intermediates: dict[str, ComputeNodeJSONType]
+    outputs: dict[str, ComputeNodeJSONType]
 
 
 def dependency_graph_validator() -> "Draft7Validator":

--- a/werkit/compute/graph/_dependency_graph.py
+++ b/werkit/compute/graph/_dependency_graph.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import inspect
 import numbers
-import sys
 import typing as t
 
 

--- a/werkit/compute/graph/_dependency_graph.py
+++ b/werkit/compute/graph/_dependency_graph.py
@@ -4,10 +4,6 @@ import numbers
 import sys
 import typing as t
 
-if sys.version_info >= (3, 8):
-    from typing import Literal, TypedDict
-else:
-    from typing_extensions import Literal, TypedDict
 
 from ._built_in_type import (
     BuiltInValueType,
@@ -18,7 +14,7 @@ from ._built_in_type import (
 )
 from ._custom_type import CustomType, JSONType
 
-if t.TYPE_CHECKING:
+if t.TYPE_CHECKING:  # pragma: no cover
     from jsonschema import Draft7Validator
 
 
@@ -98,7 +94,8 @@ class BaseNode:
             return serialized
 
 
-InputJSONType = TypedDict("InputJSONType", {"valueType": str})
+class InputJSONType(t.TypedDict):
+    valueType: str
 
 
 class Input(BaseNode):
@@ -106,9 +103,9 @@ class Input(BaseNode):
         return {"valueType": self.value_type_name}
 
 
-ComputeNodeJSONType = TypedDict(
-    "ComputeNodeJSONType", {"valueType": str, "dependencies": t.List[str]}
-)
+class ComputeNodeJSONType(t.TypedDict):
+    valueType: str
+    dependencies: t.List[str]
 
 
 class ComputeNode(BaseNode):
@@ -156,15 +153,11 @@ def output(value_type: AnyValueType) -> t.Callable[[t.Callable], Output]:
 AttrType = t.TypeVar("AttrType")
 
 
-DependencyGraphJSONType = TypedDict(
-    "DependencyGraphJSONType",
-    {
-        "schemaVersion": Literal[1],
-        "inputs": t.Dict[str, InputJSONType],
-        "intermediates": t.Dict[str, ComputeNodeJSONType],
-        "outputs": t.Dict[str, ComputeNodeJSONType],
-    },
-)
+class DependencyGraphJSONType(t.TypedDict):
+    schemaVersion: t.Literal[1]
+    inputs: t.Dict[str, InputJSONType]
+    intermediates: t.Dict[str, ComputeNodeJSONType]
+    outputs: t.Dict[str, ComputeNodeJSONType]
 
 
 def dependency_graph_validator() -> "Draft7Validator":

--- a/werkit/compute/graph/_state_manager.py
+++ b/werkit/compute/graph/_state_manager.py
@@ -35,7 +35,7 @@ class Store:
         normalized = self.normalize(**kwargs)
         self.store.update(normalized)
 
-    def serialize(self, targets: t.Optional[t.List[str]] = None) -> t.Dict:
+    def serialize(self, targets: t.Optional[t.List[str]] = None) -> dict[str, t.Any]:
         if targets is not None:
             self._assert_known_keys(targets)
             missing_keys = set(targets) - set(self.store.keys())

--- a/werkit/compute/graph/_state_manager.py
+++ b/werkit/compute/graph/_state_manager.py
@@ -49,7 +49,6 @@ class Store:
         }
 
 
-
 class StateManager(Store):
     def __init__(self, instance: t.Any):
         super().__init__(

--- a/werkit/compute/graph/_state_manager.py
+++ b/werkit/compute/graph/_state_manager.py
@@ -2,11 +2,10 @@ import typing as t
 from ._dependency_graph import ComputeNode, DependencyGraph
 
 
-class StateManager:
-    def __init__(self, instance: t.Any):
-        self.instance = instance
-        self.dependency_graph = DependencyGraph.from_class(instance.__class__)
-        self.store: t.Dict = {}
+class Store:
+    def __init__(self, dependency_graph: DependencyGraph):
+        self.dependency_graph = dependency_graph
+        self.store: dict[str, t.Any] = {}
 
     def _assert_known_keys(self, keys: t.Iterable[str]) -> None:
         unknown_keys = set(keys) - set(self.dependency_graph.keys())
@@ -35,6 +34,28 @@ class StateManager:
         self._assert_known_keys(kwargs.keys())
         normalized = self.normalize(**kwargs)
         self.store.update(normalized)
+
+    def serialize(self, targets: t.Optional[t.List[str]] = None) -> t.Dict:
+        if targets is not None:
+            self._assert_known_keys(targets)
+            missing_keys = set(targets) - set(self.store.keys())
+            if missing_keys:
+                preamble = f"{'Key has' if len(missing_keys) == 1 else 'Keys have'} not been evaluated"
+                raise ValueError(f"{preamble}: {', '.join(sorted(list(missing_keys)))}")
+        return {
+            name: self.dependency_graph.all_nodes[name].serialize_value(value)
+            for name, value in self.store.items()
+            if targets is None or name in targets
+        }
+
+
+
+class StateManager(Store):
+    def __init__(self, instance: t.Any):
+        super().__init__(
+            dependency_graph=DependencyGraph.from_class(instance.__class__)
+        )
+        self.instance = instance
 
     def evaluate(
         self, targets: t.Optional[t.List[str]] = None, handle_exceptions: bool = False
@@ -74,19 +95,6 @@ class StateManager:
         else:
             values = afx.build(targets=targets)
             self.store.update(**dict(zip(targets, values)))
-
-    def serialize(self, targets: t.Optional[t.List[str]] = None) -> t.Dict:
-        if targets is not None:
-            self._assert_known_keys(targets)
-            missing_keys = set(targets) - set(self.store.keys())
-            if missing_keys:
-                preamble = f"{'Key has' if len(missing_keys) == 1 else 'Keys have'} not been evaluated"
-                raise ValueError(f"{preamble}: {', '.join(sorted(list(missing_keys)))}")
-        return {
-            name: self.dependency_graph.all_nodes[name].serialize_value(value)
-            for name, value in self.store.items()
-            if targets is None or name in targets
-        }
 
     def get(self, name: str) -> t.Any:
         self._assert_known_keys([name])

--- a/werkit/compute/graph/_state_manager.py
+++ b/werkit/compute/graph/_state_manager.py
@@ -5,7 +5,7 @@ from ._dependency_graph import ComputeNode, DependencyGraph
 class StateManager:
     def __init__(self, instance: t.Any):
         self.instance = instance
-        self.dependency_graph = DependencyGraph(instance.__class__)
+        self.dependency_graph = DependencyGraph.from_class(instance.__class__)
         self.store: t.Dict = {}
 
     def _assert_known_keys(self, keys: t.Iterable[str]) -> None:

--- a/werkit/compute/graph/test_dependency_graph.py
+++ b/werkit/compute/graph/test_dependency_graph.py
@@ -45,30 +45,9 @@ def test_dependency_graph_serializes() -> None:
 
 
 def test_dependency_graph_serialization_matches_schema() -> None:
-    import os
-    import simplejson as json
-    from jsonschema import RefResolver, Draft7Validator
+    from ._dependency_graph import assert_valid_dependency_graph_data
 
     dependency_graph = DependencyGraph.from_class(MyComputeProcess)
     serialized = dependency_graph.serialize()
 
-    with open(
-        os.path.join(
-            os.path.dirname(__file__),
-            "..",
-            "..",
-            "..",
-            "types",
-            "src",
-            "generated",
-            "dependency-graph.schema.json",
-        ),
-        "r",
-    ) as f:
-        schema = json.load(f)
-    resolver = RefResolver.from_schema(schema)
-    validator = Draft7Validator(
-        {"$ref": "#/definitions/DependencyGraphWithBuiltInTypes"}, resolver=resolver
-    )
-
-    validator.validate(serialized)
+    assert_valid_dependency_graph_data(serialized)

--- a/werkit/compute/graph/test_dependency_graph.py
+++ b/werkit/compute/graph/test_dependency_graph.py
@@ -28,7 +28,7 @@ def test_dependency_graph_dependencies_have_correct_types() -> None:
     assert dependency_graph.outputs[EXPECTED_OUTPUT].value_type is int
 
 
-def test_dependency_graph_deserialize() -> None:
+def test_dependency_graph_deserializes() -> None:
     dependency_graph = DependencyGraph.deserialize(EXPECTED_SERIALIZED_DEPENDENCY_GRAPH)
 
     for name in EXPECTED_INPUTS:

--- a/werkit/compute/graph/test_dependency_graph.py
+++ b/werkit/compute/graph/test_dependency_graph.py
@@ -1,3 +1,5 @@
+import numbers
+
 from . import DependencyGraph
 from .testing_examples import (
     EXPECTED_INPUTS,
@@ -9,7 +11,7 @@ from .testing_examples import (
 
 
 def test_dependency_graph_collects_dependencies() -> None:
-    dependency_graph = DependencyGraph(MyComputeProcess)
+    dependency_graph = DependencyGraph.from_class(MyComputeProcess)
 
     assert set(dependency_graph.inputs.keys()) == set(EXPECTED_INPUTS)
     assert set(dependency_graph.intermediates.keys()) == set(EXPECTED_INTERMEDIATES)
@@ -17,7 +19,7 @@ def test_dependency_graph_collects_dependencies() -> None:
 
 
 def test_dependency_graph_dependencies_have_correct_types() -> None:
-    dependency_graph = DependencyGraph(MyComputeProcess)
+    dependency_graph = DependencyGraph.from_class(MyComputeProcess)
 
     for name in EXPECTED_INPUTS:
         assert dependency_graph.inputs[name].value_type is int
@@ -26,8 +28,18 @@ def test_dependency_graph_dependencies_have_correct_types() -> None:
     assert dependency_graph.outputs[EXPECTED_OUTPUT].value_type is int
 
 
+def test_dependency_graph_deserialize():
+    dependency_graph = DependencyGraph.deserialize(EXPECTED_SERIALIZED_DEPENDENCY_GRAPH)
+
+    for name in EXPECTED_INPUTS:
+        assert dependency_graph.inputs[name].value_type is numbers.Number
+    for name in EXPECTED_INTERMEDIATES:
+        assert dependency_graph.intermediates[name].value_type is numbers.Number
+    assert dependency_graph.outputs[EXPECTED_OUTPUT].value_type is numbers.Number
+
+
 def test_dependency_graph_serializes() -> None:
-    dependency_graph = DependencyGraph(MyComputeProcess)
+    dependency_graph = DependencyGraph.from_class(MyComputeProcess)
 
     assert dependency_graph.serialize() == EXPECTED_SERIALIZED_DEPENDENCY_GRAPH
 
@@ -37,7 +49,7 @@ def test_dependency_graph_serialization_matches_schema() -> None:
     import simplejson as json
     from jsonschema import RefResolver, Draft7Validator
 
-    dependency_graph = DependencyGraph(MyComputeProcess)
+    dependency_graph = DependencyGraph.from_class(MyComputeProcess)
     serialized = dependency_graph.serialize()
 
     with open(

--- a/werkit/compute/graph/test_dependency_graph.py
+++ b/werkit/compute/graph/test_dependency_graph.py
@@ -28,7 +28,7 @@ def test_dependency_graph_dependencies_have_correct_types() -> None:
     assert dependency_graph.outputs[EXPECTED_OUTPUT].value_type is int
 
 
-def test_dependency_graph_deserialize():
+def test_dependency_graph_deserialize() -> None:
     dependency_graph = DependencyGraph.deserialize(EXPECTED_SERIALIZED_DEPENDENCY_GRAPH)
 
     for name in EXPECTED_INPUTS:

--- a/werkit/compute/graph/testing_examples.py
+++ b/werkit/compute/graph/testing_examples.py
@@ -1,6 +1,7 @@
 import typing as t
 from . import (
     CustomType,
+    DependencyGraphJSONType,
     Input,
     JSONType,
     bind_state_manager,
@@ -31,7 +32,7 @@ EXPECTED_INPUTS = ["a", "b"]
 EXPECTED_INTERMEDIATES = ["i", "j"]
 EXPECTED_OUTPUT = "r"
 
-EXPECTED_SERIALIZED_DEPENDENCY_GRAPH = {
+EXPECTED_SERIALIZED_DEPENDENCY_GRAPH: DependencyGraphJSONType = {
     "schemaVersion": 1,
     "inputs": {"a": {"valueType": "number"}, "b": {"valueType": "number"}},
     "intermediates": {

--- a/werkit/orchestrator/orchestrator_lambda/parallel.py
+++ b/werkit/orchestrator/orchestrator_lambda/parallel.py
@@ -1,6 +1,5 @@
 import asyncio
 import datetime
-import json
 import typing as t
 from concurrent.futures import ThreadPoolExecutor
 import boto3
@@ -21,6 +20,8 @@ async def call_worker_service(
     event_loop: asyncio.AbstractEventLoop = event_loop,
     executor: t.Optional[ThreadPoolExecutor] = None,
 ) -> t.Any:
+    from missouri import json
+
     def invoke_lambda() -> "InvocationResponseTypeDef":
         return lambda_client.invoke(
             FunctionName=worker_lambda_function_name, Payload=json.dumps(_input)

--- a/werkit/orchestrator/orchestrator_lambda/parallel.py
+++ b/werkit/orchestrator/orchestrator_lambda/parallel.py
@@ -20,7 +20,7 @@ async def call_worker_service(
     event_loop: asyncio.AbstractEventLoop = event_loop,
     executor: t.Optional[ThreadPoolExecutor] = None,
 ) -> t.Any:
-    from missouri import json
+    import json
 
     def invoke_lambda() -> "InvocationResponseTypeDef":
         return lambda_client.invoke(

--- a/werkit/orchestrator/testing/test_integration.py
+++ b/werkit/orchestrator/testing/test_integration.py
@@ -80,7 +80,7 @@ EXAMPLE_MESSAGE_KEY = {"someParameters": ["just", "a", "message", "key", "nbd"]}
 
 
 def invoke_orchestrator(orchestrator_function_name: str) -> dict[str, t.Any]:
-    from missouri import json
+    import json
 
     message = {
         "message_key": EXAMPLE_MESSAGE_KEY,
@@ -99,7 +99,7 @@ def invoke_orchestrator(orchestrator_function_name: str) -> dict[str, t.Any]:
         FunctionName=orchestrator_function_name,
         Payload=json.dumps(message),
     )
-    return json.load(response["Payload"])
+    return t.cast(dict[str, t.Any], json.load(response["Payload"]))
 
 
 @pytest.mark.slow

--- a/werkit/orchestrator/testing/test_integration.py
+++ b/werkit/orchestrator/testing/test_integration.py
@@ -80,7 +80,7 @@ EXAMPLE_MESSAGE_KEY = {"someParameters": ["just", "a", "message", "key", "nbd"]}
 
 
 def invoke_orchestrator(orchestrator_function_name: str) -> dict[str, t.Any]:
-    import json
+    from missouri import json
 
     message = {
         "message_key": EXAMPLE_MESSAGE_KEY,


### PR DESCRIPTION
- To create DependencyGraph from a class, use `DependencyGraph.from_class()` instead of `DependencyGraph()`
- Add `DependencyGraph.deserialize()`
- Extract Store superclass from StateManager