### PR TITLE
StateManager: Eliminate some type errors downstream

### DIFF
--- a/werkit/compute/graph/__init__.py
+++ b/werkit/compute/graph/__init__.py
@@ -2,7 +2,7 @@ from ._binding import DefaultStateManagerProtocol, bind_state_manager  # noqa: F
 from ._built_in_type import (  # noqa: F401
     BuiltInValueType,
 )
-from ._custom_type import CustomType, JSONType  # noqa: F401
+from ._custom_type import CustomType  # noqa: F401
 from ._dependency_graph import (  # noqa: F401
     ComputeNode,
     DependencyGraph,

--- a/werkit/compute/graph/_custom_type.py
+++ b/werkit/compute/graph/_custom_type.py
@@ -4,8 +4,6 @@ from abc import ABC, abstractmethod
 if t.TYPE_CHECKING:  # pragma: no cover
     from jsonschema import Draft7Validator
 
-JSONType = t.Union[str, int, float, bool, None, dict[str, t.Any], t.List[t.Any]]
-
 CanonicalType = t.TypeVar("CanonicalType")
 
 
@@ -49,7 +47,7 @@ class CustomType(ABC, t.Generic[CanonicalType]):
         return f"#/definitions/{cls.name()}"
 
     @classmethod
-    def validate(cls, json_data: JSONType) -> None:
+    def validate(cls, json_data: t.Any) -> None:
         """
         Validate the JSON representation.
         """
@@ -71,7 +69,7 @@ class CustomType(ABC, t.Generic[CanonicalType]):
 
     @classmethod
     @abstractmethod
-    def deserialize(cls, json_data: JSONType) -> CanonicalType:
+    def deserialize(cls, json_data: t.Any) -> CanonicalType:
         """
         Convert the JSON representation to the canonical native type.
         """
@@ -86,7 +84,7 @@ class CustomType(ABC, t.Generic[CanonicalType]):
 
     @classmethod
     @abstractmethod
-    def serialize(self, value: CanonicalType) -> JSONType:
+    def serialize(self, value: CanonicalType) -> t.Any:
         """
         Convert the canonical native type to a JSON representation.
         """

--- a/werkit/compute/graph/_dependency_graph.py
+++ b/werkit/compute/graph/_dependency_graph.py
@@ -11,7 +11,7 @@ from ._built_in_type import (
     coerce_value_to_builtin_type,
     is_built_in_value_type,
 )
-from ._custom_type import CustomType, JSONType
+from ._custom_type import CustomType
 
 if t.TYPE_CHECKING:  # pragma: no cover
     from jsonschema import Draft7Validator
@@ -64,7 +64,7 @@ class BaseNode:
         else:
             return t.cast(type[CustomType], self.value_type).name()
 
-    def deserialize(self, value: JSONType) -> t.Any:
+    def deserialize(self, value: t.Any) -> t.Any:
         if self.value_type_is_built_in:
             return value
         else:
@@ -83,7 +83,7 @@ class BaseNode:
             # TODO: Perhaps catch and re-throw to improve the error message.
             return t.cast(t.Type[CustomType], self.value_type).normalize(value)
 
-    def serialize_value(self, value: t.Any) -> JSONType:
+    def serialize_value(self, value: t.Any) -> t.Any:
         if self.value_type_is_built_in:
             return value
         else:

--- a/werkit/compute/graph/testing_examples.py
+++ b/werkit/compute/graph/testing_examples.py
@@ -3,7 +3,6 @@ from . import (
     CustomType,
     DependencyGraphJSONType,
     Input,
-    JSONType,
     bind_state_manager,
     intermediate,
     output,
@@ -86,7 +85,7 @@ class MyModelType(CustomType[MyModel]):
         return value
 
     @classmethod
-    def serialize(self, value: MyModel) -> JSONType:
+    def serialize(self, value: MyModel) -> t.Any:
         return {
             "title": value.title,
             "description": value.description,
@@ -94,7 +93,7 @@ class MyModelType(CustomType[MyModel]):
         }
 
     @classmethod
-    def deserialize(self, json_data: JSONType) -> MyModel:
+    def deserialize(self, json_data: t.Any) -> MyModel:
         json_data = t.cast(dict, json_data)
         return MyModel(**json_data)
 
@@ -113,11 +112,11 @@ class Vector3(CustomType[tuple]):
         return tuple(round(coord, cls.DECIMALS) for coord in value)
 
     @classmethod
-    def serialize(self, value: tuple) -> JSONType:
+    def serialize(self, value: tuple) -> t.Any:
         return list(value)
 
     @classmethod
-    def deserialize(self, json_data: JSONType) -> tuple:
+    def deserialize(self, json_data: t.Any) -> tuple:
         json_data = t.cast(list, json_data)
         return tuple(json_data)
 


### PR DESCRIPTION
```
error: Argument 1 of "deserialize" is incompatible with supertype "CustomType"; supertype defines the argument type as "Union[str, int, float, bool, None, Dict[str, Any], List[Any]]"  [override]
note: This violates the Liskov substitution principle
note: See https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
```