### PR TITLE
Fix downstream type errors

### DIFF
--- a/types/package.json
+++ b/types/package.json
@@ -26,6 +26,7 @@
   ],
   "dependencies": {
     "@metabolize/uuid-to-hex": "^2.0.0",
+    "@types/node": "20.4.2",
     "uuid": "^9.0.0"
   },
   "optionalDependencies": {
@@ -36,7 +37,6 @@
     "@types/chai": "4.3.5",
     "@types/chai-string": "1.4.2",
     "@types/mocha": "10.0.1",
-    "@types/node": "20.4.2",
     "@types/uuid": "9.0.2",
     "aws-sdk": "2.1415.0",
     "chai": "4.3.7",


### PR DESCRIPTION
```
node_modules/werkit/dist/s3.d.ts:1:23 - error TS2688: Cannot find type definition file for 'node'.

1 /// <reference types="node" />
                        ~~~~

node_modules/werkit/dist/s3.d.ts:11:16 - error TS2304: Cannot find name 'BufferEncoding'.

11     encoding?: BufferEncoding;
                  ~~~~~~~~~~~~~~
```