### PR TITLE
Manager: Add `work()` function; do not invoke work_fn when validation fails

### DIFF
--- a/werkit/compute/_manager.py
+++ b/werkit/compute/_manager.py
@@ -53,18 +53,18 @@ class Manager:
             the nearest hundredth of a second.
 
     Example:
+        def work():
+            result = perform_computation()
+            # If needed, convert result to JSON-serializable objects.
+            return transform(result)
 
-        with Manager(
+        manager = Manager(
             input_message=params,
             schema=schema,
             handle_exceptions=handle_exceptions,
             verbose=verbose,
-        ) as manager:
-            result = perform_computation()
-            # If needed, convert result to JSON-serializable objects.
-            serialized = transform(result)
-            manager.result = serialized
-        return manager.output_message
+        )
+        output_message = manager.work(work)
     """
 
     message_key: t.Any
@@ -212,3 +212,17 @@ class Manager:
             )
 
         return None
+
+    def work(self, work_fn: t.Callable) -> dict[str, t.Any]:
+        with self:
+            try:
+                self.schema.input_message.validate(self.input_message)
+            except:  # noqa: E722
+                if not self.__exit__(*sys.exc_info()):
+                    raise
+                else:
+                    return self.output_message
+
+            self.result = work_fn(self.input_message)
+
+        return self.output_message


### PR DESCRIPTION
This fixes an issue where the body of the handler would run even when input validation fails. The previous behavior was to send _two_ messages, one for the validation failure, and then one for the execution of the body.

This was a bad surprise and unfortunately wasn't fixable with the current API. That's because a context handler was simply the wrong interface here. They aren't meant for conditional execution of the block, nor capable of that – at least not without resorting to hacking the runtime.

https://stackoverflow.com/a/12594323/893113

The new interface adds a `work()` method which takes a callback function instead. That function is invoked only when validation succeeds.

Fix #424